### PR TITLE
Clean up selection logic

### DIFF
--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -151,7 +151,7 @@ const createReducer = <T extends DataType>() => (
       const filteredRows = action.filter(state.originalRows);
       const selectedRowsById: { [key: number]: boolean } = {};
       state.selectedRows.map(row => {
-        selectedRowsById[row.id] = row.selected ? true : false;
+        selectedRowsById[row.id] = !!row.selected;
       });
 
       return {
@@ -183,47 +183,32 @@ const createReducer = <T extends DataType>() => (
       });
 
       stateCopy.selectedRows = stateCopy.originalRows.filter(
-        row => row.selected === true
+        row => row.selected
       );
 
       stateCopy.toggleAllState =
-        stateCopy.selectedRows.length === stateCopy.rows.length
-          ? (stateCopy.toggleAllState = true)
-          : (stateCopy.toggleAllState = false);
+        stateCopy.selectedRows.length === stateCopy.rows.length;
 
       return stateCopy;
     case 'SEARCH_STRING':
       const stateCopySearch = { ...state };
-      stateCopySearch.rows = stateCopySearch.originalRows.filter(row => {
-        return (
-          row.cells.filter(cell => {
-            if (cell.value.includes(action.searchString)) {
-              return true;
-            }
-            return false;
-          }).length > 0
-        );
-      });
+      stateCopySearch.rows = stateCopySearch.originalRows.filter(
+        row =>
+          row.cells.filter(cell => cell.value.includes(action.searchString))
+            .length > 0
+      );
       return stateCopySearch;
     case 'TOGGLE_ALL':
       const stateCopyToggle = { ...state };
       const rowIds: { [key: number]: boolean } = {};
 
-      if (state.selectedRows.length < state.rows.length) {
-        stateCopyToggle.rows = stateCopyToggle.rows.map(row => {
-          rowIds[row.id] = true;
-          return { ...row, selected: true };
-        });
+      const selected = state.selectedRows.length < state.rows.length;
+      stateCopyToggle.rows = stateCopyToggle.rows.map(row => {
+        rowIds[row.id] = selected;
+        return { ...row, selected };
+      });
 
-        stateCopyToggle.toggleAllState = true;
-      } else {
-        stateCopyToggle.rows = stateCopyToggle.rows.map(row => {
-          rowIds[row.id] = false;
-
-          return { ...row, selected: false };
-        });
-        stateCopyToggle.toggleAllState = false;
-      }
+      stateCopyToggle.toggleAllState = selected;
 
       stateCopyToggle.originalRows = stateCopyToggle.originalRows.map(row => {
         return row.id in rowIds

--- a/src/test/selection.spec.tsx
+++ b/src/test/selection.spec.tsx
@@ -128,27 +128,31 @@ const TableWithSelectionAndFiltering = <T extends DataType>({
   const [searchString, setSearchString] = useState('');
   const [filterOn, setFilterOn] = useState(false);
 
-  const { headers, rows, selectRow, selectedRows } = useTable(columns, data, {
-    selectable: true,
-    filter: useCallback(
-      (rows: RowType<T>[]) => {
-        return rows.filter(row => {
-          return (
-            row.cells.filter(cell => {
-              if (typeof cell.value !== 'string') {
-                return false;
-              }
+  const { headers, rows, selectRow, selectedRows, toggleAll } = useTable(
+    columns,
+    data,
+    {
+      selectable: true,
+      filter: useCallback(
+        (rows: RowType<T>[]) => {
+          return rows.filter(row => {
+            return (
+              row.cells.filter(cell => {
+                if (typeof cell.value !== 'string') {
+                  return false;
+                }
 
-              return cell.value.toLowerCase().includes(searchString)
-                ? true
-                : false;
-            }).length > 0
-          );
-        });
-      },
-      [searchString]
-    ),
-  });
+                return cell.value.toLowerCase().includes(searchString)
+                  ? true
+                  : false;
+              }).length > 0
+            );
+          });
+        },
+        [searchString]
+      ),
+    }
+  );
 
   return (
     <>
@@ -164,6 +168,7 @@ const TableWithSelectionAndFiltering = <T extends DataType>({
       >
         Filter
       </button>
+      <button data-testid="toggle-all" onClick={() => toggleAll()}></button>
       <table>
         <thead>
           <tr>
@@ -211,6 +216,7 @@ test('Should be able to select rows while filtering', async () => {
   render(<TableWithSelectionAndFiltering columns={userCols} data={userData} />);
   let checkbox = screen.getByTestId('checkbox-0') as HTMLInputElement;
   const checkbox2 = screen.getByTestId('checkbox-1') as HTMLInputElement;
+  const toggleAllButton = screen.getByTestId('toggle-all') as HTMLInputElement;
 
   const input = screen.getByTestId('input');
 
@@ -244,6 +250,14 @@ test('Should be able to select rows while filtering', async () => {
   fireEvent.change(input, { target: { value: 'ye' } });
 
   expect(screen.queryAllByTestId('row')).toHaveLength(1);
+
+  // toggle all
+  fireEvent.click(toggleAllButton);
+  expect(screen.queryAllByTestId('selected-row')).toHaveLength(1);
+
+  // toggle all off
+  fireEvent.click(toggleAllButton);
+  expect(screen.queryAllByTestId('selected-row')).toHaveLength(0);
 
   checkbox = screen.getByTestId('checkbox-0') as HTMLInputElement;
   fireEvent.click(checkbox);


### PR DESCRIPTION
**Summary:**

- Cleaning up some repetitive boolean logic on filters, checks, and assignments
- Adds an extra test-case to cover an uncovered code branch of selection
- Removes some repetitive code by swapping hardcoded `true`/`false` for the `if` logic