### PR TITLE
Update Package Exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,20 +1,33 @@
 {
+  "name": "react-final-table",
   "version": "1.4.2",
   "license": "MIT",
   "author": "Gabriel Abud",
+  "keywords": [
+    "react",
+    "hooks",
+    "typescript",
+    "table",
+    "headless",
+    "react-hooks"
+  ],
   "main": "dist/index.js",
-  "typings": "dist/index.d.ts",
+  "module": "dist/react-final-table.esm.js",
+  "types": "dist/index.d.ts",
   "files": [
     "dist",
     "src"
   ],
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/react-final-table.esm.js"
+    }
+  },
+  "sideEffects": false,
   "engines": {
     "node": ">=10"
-  },
-  "prettier": {
-    "printWidth": 80,
-    "singleQuote": true,
-    "trailingComma": "es5"
   },
   "scripts": {
     "start": "tsdx watch",
@@ -26,17 +39,7 @@
     "prepare": "tsdx build",
     "watch": "tsdx watch"
   },
-  "peerDependencies": {
-    "react": ">=16"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "tsdx lint"
-    }
-  },
-  "testEnvironment": "jest-environment-jsdom-sixteen",
-  "name": "react-final-table",
-  "module": "dist/react-final-table.esm.js",
+  "dependencies": {},
   "devDependencies": {
     "@babel/core": "^7.11.4",
     "@testing-library/jest-dom": "^5.11.3",
@@ -58,6 +61,9 @@
     "tslib": "^2.0.1",
     "typescript": "^3.9.7"
   },
+  "peerDependencies": {
+    "react": ">=16"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/Buuntu/react-final-table"
@@ -66,5 +72,15 @@
     "url": "https://github.com/Buuntu/react-final-table/issues"
   },
   "homepage": "https://github.com/Buuntu/react-final-table#readme",
-  "dependencies": {}
+  "husky": {
+    "hooks": {
+      "pre-commit": "tsdx lint"
+    }
+  },
+  "prettier": {
+    "printWidth": 80,
+    "singleQuote": true,
+    "trailingComma": "es5"
+  },
+  "testEnvironment": "jest-environment-jsdom-sixteen"
 }


### PR DESCRIPTION
**Summary:**

- Adds `keywords` field to `package.json` as recommended
  - https://docs.skypack.dev/package-authors/package-checks#keywords
- Adds `exports` field to `package.json` as recommended
  - https://docs.skypack.dev/package-authors/package-checks#export-map
  - https://nodejs.org/api/packages.html#packages_subpath_exports
- Adds `sideEffect: false` to `package.json` to enable tree-shaking in Webpack
  - https://webpack.js.org/guides/tree-shaking/
- Adds `./package.json` export to export map for React Native
  - https://github.com/react-hook-form/react-hook-form/issues/3257
- Adds `module` key to `package.json` for ESM support
- Swapped `typings` to `types` (`types` appears to be more commonly used)