### PR TITLE
Bump peer dependency react to require version able to use hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "typescript": "^3.9.7"
   },
   "peerDependencies": {
-    "react": ">=16"
+    "react": ">=16.8.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Summary:**

- Bumps `peerDependencies` `react` to `v16.8.0` which is the minimum version to use hooks.