### PR TITLE
Modify release to commit the updated package version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Install Modules
         run: npm i
@@ -24,7 +26,10 @@ jobs:
 
       - uses: codecov/codecov-action@v1
 
-      - uses: codfish/semantic-release-action@master
+      - uses: cycjimmy/semantic-release-action@v2
+        with:
+          extra_plugins: |
+            @semantic-release/git
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -1,0 +1,16 @@
+module.exports = {
+  plugins: [
+    '@semantic-release/commit-analyzer',
+    '@semantic-release/release-notes-generator',
+    '@semantic-release/npm',
+    '@semantic-release/github',
+    [
+      '@semantic-release/git',
+      {
+        assets: ['package.json', 'package-lock.json'],
+        message:
+          'release(version): release ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
+      },
+    ],
+  ],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-final-table",
-  "version": "1.4.2",
+  "version": "1.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test": "tsdx test --passWithNoTests",
     "test:watch": "tsdx test --passWithNoTests --watch",
     "test:coverage": "tsdx test --passWithNoTests --collect-coverage",
-    "lint": "tsdx lint",
+    "lint": "tsdx lint src",
     "prepare": "tsdx build",
     "watch": "tsdx watch"
   },
@@ -73,7 +73,7 @@
   "homepage": "https://github.com/Buuntu/react-final-table#readme",
   "husky": {
     "hooks": {
-      "pre-commit": "tsdx lint"
+      "pre-commit": "tsdx lint src"
     }
   },
   "prettier": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-final-table",
-  "version": "1.4.2",
+  "version": "1.5.1",
   "license": "MIT",
   "author": "Gabriel Abud",
   "keywords": [


### PR DESCRIPTION
**Summary:**

- Utilizes `@semantic-release/git` to commit the changes to `package.json` and `package-lock.json` after a release.
- Bumps the version to the current `1.5.1`
- Adds `src` to the `tsdx lint` commands to prevent it from throwing a warning in the console

**NOTE:** Wasn't sure what type and scope to use for the release commit message. I'm more than willing to change it.

Closes #39 